### PR TITLE
Emitter changes - small error fix with LED blinking array/index handling

### DIFF
--- a/Software/Emitter/irda_robi/Emitter.ino
+++ b/Software/Emitter/irda_robi/Emitter.ino
@@ -8,7 +8,6 @@
 // we could use an array of uint16_t for a almost perfect timing but the attiny will see his RAM burning
 // 0, 10, 20, 30, 40, 50, 60, 70, 80, 90,   105, 115, 125, 135, 145, 155, 165, 175, 185, 195,   210, 220, 230, 240, 250, 260, 270, 280, 290, 300,   315, 325, 335, 345, 355, 365, 375, 385, 395, 405
 
-
 // attiny85
 // LEDIR PB1 ?
 // LEDPIN PB0 ?
@@ -25,8 +24,6 @@
   #define RESETPIN PA6 // reset pin only at start! need test...
 #endif
 
-
-//#define PERIOD_PULSE 2 //use NOP now as _delay_us is 4us mini
 #define PERIOD_WAIT_START 6
 #define PERIOD_WAIT_BIT 5 // for a complete loop of approx 10us
 #define PERIOD_WAIT_NEXT_BYTE 10
@@ -34,7 +31,7 @@
 
 // define tx_id or let to 0 for a "true" random ID.
 uint32_t txID = 0;
-bool resetID = false; // set True to force reset ID at "each" reboot...
+bool resetID = false; // set to true to force reset ID at "each" reboot, but you don't need that :)
 
 // scheme is: [0] LSB 8bit ID + [1] 8Bit ID + [2] 8bit ID + [3] CheckSUM + [4] PARITY(XXXXX000)msb or lsb... 
 uint8_t arrayID[ARRAY_ID_LEN] = {};
@@ -126,7 +123,7 @@ void codeLoop() {
         // 3x1Byte + 1Byte checksum,
         for (uint8_t i = 0 ; i < 4; i++)
         { // [0] to [2] + checksum
-            idMask = 0x80; // 128; // 0b10000000
+            idMask = 0x80; // 128 or 0b10000000
             pulse(true); // start byte
             _delay_us(PERIOD_WAIT_START);
 
@@ -245,7 +242,8 @@ uint8_t getCRC8(const uint8_t *data, size_t len) {
 
 // Pulse or no pulse but with "almost" good time length
 // Yes... an interrupt based pulse could be better... pull request kindly accepted :-)
-void pulse(bool state) {
+void pulse(bool state)
+{
     if(state)
     {
         PORTB |= (1 << LEDIR);      //replaces digitalWrite(, HIGH);

--- a/Software/Emitter/irda_robi/Emitter.ino
+++ b/Software/Emitter/irda_robi/Emitter.ino
@@ -103,14 +103,9 @@ void loop() {
             #endif
         }
     //      digitalWrite(LEDPIN, state % 2 ? HIGH : LOW); //use PORTB... as digitalWrite use more than 120bits
-        if (state > sizeof(intervals))
-        {
-            state = 0;
-        }
-        else
-        {
-            state++;
-        }
+      state++;
+      if (state >= sizeof(intervals))
+          state = 0;
         counterLoop = 0;
     }
     counterLoop++;

--- a/Software/Emitter/irda_robi/Emitter.ino
+++ b/Software/Emitter/irda_robi/Emitter.ino
@@ -1,5 +1,6 @@
 // Robitronic compatible attinyX4 transmitter
 
+//#define __AVR_ATtinyX5__ // It seems like if you try to compile for ATtinyX5, the define is missing, so you'll have to set it manually
 #include <EEPROM.h>
 
 //#define NOP __asm__ __volatile__ ("nop\n\t")


### PR DESCRIPTION
please check line 106-108.
I think original code ran over the array, as sizeof(intervals) was 4,
if (state > sizeof(intervals)) - this was only true when state was already 5, but the array indexes are in the range 0-3.

how to observe: LED blinked at the end of the "loop" for a millisec, almost unnoticeably.